### PR TITLE
Fix user ID used for alarm detail

### DIFF
--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmDetailActivity.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmDetailActivity.java
@@ -9,6 +9,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.util.ArrayList;
@@ -20,7 +22,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
     private ArrayList<AlarmItem> alarmItems = new ArrayList<>();
     private FirebaseFirestore db;
 
-    private String userId = "zxcxzc123"; // 🔥 Firestore 콘솔에 저장된 사용자 ID
+    private String userId;               // Firebase에 저장된 사용자 ID
     private String selectedDate;         // ex: "2025-06-09"
     private Button btnSave;
 
@@ -30,6 +32,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
         setContentView(R.layout.activity_alarm_detail);
 
         db = FirebaseFirestore.getInstance();
+        userId = getCurrentUserId();
 
         recyclerView = findViewById(R.id.recyclerViewAlarmDetail);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
@@ -96,5 +99,13 @@ public class AlarmDetailActivity extends AppCompatActivity {
                 .addOnFailureListener(e -> {
                     Toast.makeText(this, "저장 실패: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                 });
+    }
+
+    private String getCurrentUserId() {
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null && user.getEmail() != null) {
+            return user.getEmail().split("@")[0];
+        }
+        return "unknown_user";
     }
 }


### PR DESCRIPTION
## Summary
- set userId dynamically using FirebaseAuth when editing alarms

## Testing
- `./gradlew tasks --all` *(fails: `Unable to tunnel through proxy`)*

------
https://chatgpt.com/codex/tasks/task_e_68482fbaf808832aba50715358d57307