### PR TITLE
Fix user ID used for alarm detail

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -29,6 +31,7 @@
         <activity android:name=".AlarmRegisterActivity" />
         <activity android:name=".AlarmDetailActivity" />
 
+        <receiver android:name=".AlarmReceiver" />
 
     </application>
 

--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmDetailActivity.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmDetailActivity.java
@@ -9,7 +9,10 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.example.wooyongproj_20202798.AlarmNotificationHelper;
 
 import java.util.ArrayList;
 
@@ -20,8 +23,10 @@ public class AlarmDetailActivity extends AppCompatActivity {
     private ArrayList<AlarmItem> alarmItems = new ArrayList<>();
     private FirebaseFirestore db;
 
-    private String userId = "zxcxzc123"; // 🔥 Firestore 콘솔에 저장된 사용자 ID
+    private String userId;               // Firebase에 저장된 사용자 ID
     private String selectedDate;         // ex: "2025-06-09"
+    private String medName;              // 약 이름
+    private int originalItemCount = 0;   // 기존 알림 개수
     private Button btnSave;
 
     @Override
@@ -30,6 +35,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
         setContentView(R.layout.activity_alarm_detail);
 
         db = FirebaseFirestore.getInstance();
+        userId = getCurrentUserId();
 
         recyclerView = findViewById(R.id.recyclerViewAlarmDetail);
         recyclerView.setLayoutManager(new LinearLayoutManager(this));
@@ -39,6 +45,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
         btnSave = findViewById(R.id.btnSave);
 
         selectedDate = getIntent().getStringExtra("selectedDate");
+        medName = getIntent().getStringExtra("medName");
 
         // ✅ 디버깅 로그 출력
         Log.d("AlarmDetail", "userId: " + userId);
@@ -66,6 +73,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
                         if (alarmData != null && alarmData.getAlarmItems() != null) {
                             alarmItems.clear();
                             alarmItems.addAll(alarmData.getAlarmItems());
+                            originalItemCount = alarmItems.size();
                             adapter.notifyDataSetChanged();
                         }
                     } else {
@@ -80,7 +88,7 @@ public class AlarmDetailActivity extends AppCompatActivity {
 
     private void saveAlarmDataToFirestore() {
         AlarmData updatedData = new AlarmData();
-        updatedData.setMedName("kamki"); // TODO: 실제 이름 연동 필요 시 수정
+        updatedData.setMedName(medName == null ? "" : medName);
         updatedData.setAlarmItems(alarmItems);
         updatedData.setDate(selectedDate);
 
@@ -90,11 +98,21 @@ public class AlarmDetailActivity extends AppCompatActivity {
                 .document(selectedDate)
                 .set(updatedData)
                 .addOnSuccessListener(aVoid -> {
+                    AlarmNotificationHelper.cancelAlarms(this, selectedDate, originalItemCount);
+                    AlarmNotificationHelper.scheduleAlarms(this, selectedDate, alarmItems);
                     Toast.makeText(this, "저장 완료!", Toast.LENGTH_SHORT).show();
                     finish();
                 })
                 .addOnFailureListener(e -> {
                     Toast.makeText(this, "저장 실패: " + e.getMessage(), Toast.LENGTH_SHORT).show();
                 });
+    }
+
+    private String getCurrentUserId() {
+        FirebaseUser user = FirebaseAuth.getInstance().getCurrentUser();
+        if (user != null && user.getEmail() != null) {
+            return user.getEmail().split("@")[0];
+        }
+        return "unknown_user";
     }
 }

--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmListAdapter.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmListAdapter.java
@@ -2,13 +2,19 @@ package com.example.wooyongproj_20202798;
 
 import android.content.Context;
 import android.content.Intent;
+import android.widget.Toast;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageButton;
 import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
+import com.google.firebase.auth.FirebaseAuth;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.QueryDocumentSnapshot;
+import com.example.wooyongproj_20202798.AlarmNotificationHelper;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -62,6 +68,30 @@ public class AlarmListAdapter extends RecyclerView.Adapter<AlarmListAdapter.Alar
             intent.putExtra("selectedDate", selectedDate);
             context.startActivity(intent);
         });
+
+        holder.btnDelete.setOnClickListener(v -> {
+            Context context = v.getContext();
+            String userId = FirebaseAuth.getInstance().getCurrentUser().getEmail().split("@")[0];
+            FirebaseFirestore db = FirebaseFirestore.getInstance();
+
+            db.collection("users")
+                    .document(userId)
+                    .collection("alarms")
+                    .whereEqualTo("medName", alarmData.getMedName())
+                    .get()
+                    .addOnSuccessListener(querySnapshot -> {
+                        for (QueryDocumentSnapshot doc : querySnapshot) {
+                            AlarmData data = doc.toObject(AlarmData.class);
+                            AlarmNotificationHelper.cancelAlarms(context, doc.getId(), data.getAlarmItems().size());
+                            doc.getReference().delete();
+                        }
+
+                        int pos = holder.getAdapterPosition();
+                        alarmList.remove(pos);
+                        notifyItemRemoved(pos);
+                    })
+                    .addOnFailureListener(e -> Toast.makeText(context, "삭제 실패", Toast.LENGTH_SHORT).show());
+        });
     }
 
 
@@ -74,11 +104,13 @@ public class AlarmListAdapter extends RecyclerView.Adapter<AlarmListAdapter.Alar
 
     public static class AlarmViewHolder extends RecyclerView.ViewHolder {
         TextView tvMedName, tvTimes;
+        ImageButton btnDelete;
 
         public AlarmViewHolder(@NonNull View itemView) {
             super(itemView);
             tvMedName = itemView.findViewById(R.id.tvMedName);
             tvTimes = itemView.findViewById(R.id.tvTimes);
+            btnDelete = itemView.findViewById(R.id.btnDelete);
         }
     }
 }

--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmNotificationHelper.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmNotificationHelper.java
@@ -1,0 +1,59 @@
+package com.example.wooyongproj_20202798;
+
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import java.util.Calendar;
+import java.util.List;
+
+public class AlarmNotificationHelper {
+
+    public static void scheduleAlarms(Context context, String dateKey, List<AlarmItem> items) {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        for (int i = 0; i < items.size(); i++) {
+            AlarmItem item = items.get(i);
+            if (!item.isEnabled()) continue;
+            Calendar cal = buildCalendar(dateKey, item.getTime());
+            if (cal == null || cal.before(Calendar.getInstance())) continue;
+
+            Intent intent = new Intent(context, AlarmReceiver.class);
+            intent.putExtra("label", item.getLabel());
+            int requestCode = (dateKey + i).hashCode();
+            PendingIntent pi = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            if (alarmManager != null) {
+                alarmManager.setExactAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, cal.getTimeInMillis(), pi);
+            }
+        }
+    }
+
+    public static void cancelAlarms(Context context, String dateKey, int itemCount) {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        for (int i = 0; i < itemCount; i++) {
+            Intent intent = new Intent(context, AlarmReceiver.class);
+            int requestCode = (dateKey + i).hashCode();
+            PendingIntent pi = PendingIntent.getBroadcast(context, requestCode, intent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+            if (alarmManager != null) {
+                alarmManager.cancel(pi);
+            }
+        }
+    }
+
+    private static Calendar buildCalendar(String dateKey, String time) {
+        try {
+            String[] dateParts = dateKey.split("-");
+            String[] timeParts = time.split(":");
+            Calendar cal = Calendar.getInstance();
+            cal.set(Calendar.YEAR, Integer.parseInt(dateParts[0]));
+            cal.set(Calendar.MONTH, Integer.parseInt(dateParts[1]) - 1);
+            cal.set(Calendar.DAY_OF_MONTH, Integer.parseInt(dateParts[2]));
+            cal.set(Calendar.HOUR_OF_DAY, Integer.parseInt(timeParts[0]));
+            cal.set(Calendar.MINUTE, Integer.parseInt(timeParts[1]));
+            cal.set(Calendar.SECOND, 0);
+            return cal;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmReceiver.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmReceiver.java
@@ -1,0 +1,37 @@
+package com.example.wooyongproj_20202798;
+
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
+
+public class AlarmReceiver extends BroadcastReceiver {
+
+    private static final String CHANNEL_ID = "med_alarm_channel";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String label = intent.getStringExtra("label");
+        createNotificationChannel(context);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(android.R.drawable.ic_dialog_info)
+                .setContentTitle("복용 알림")
+                .setContentText(label + " 복용 시간입니다")
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setAutoCancel(true);
+
+        NotificationManagerCompat.from(context).notify((int) System.currentTimeMillis(), builder.build());
+    }
+
+    private void createNotificationChannel(Context context) {
+        NotificationManager manager = context.getSystemService(NotificationManager.class);
+        if (manager.getNotificationChannel(CHANNEL_ID) == null) {
+            NotificationChannel channel = new NotificationChannel(CHANNEL_ID, "Medication Alarm", NotificationManager.IMPORTANCE_HIGH);
+            manager.createNotificationChannel(channel);
+        }
+    }
+}

--- a/app/src/main/java/com/example/wooyongproj_20202798/AlarmRegisterActivity.java
+++ b/app/src/main/java/com/example/wooyongproj_20202798/AlarmRegisterActivity.java
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.firestore.FirebaseFirestore;
+import com.example.wooyongproj_20202798.AlarmNotificationHelper;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -105,6 +106,7 @@ public class AlarmRegisterActivity extends AppCompatActivity {
                         .document(dateKey)
                         .set(data)
                         .addOnSuccessListener(aVoid -> {
+                            AlarmNotificationHelper.scheduleAlarms(this, dateKey, dayItems);
                             if (index == duration - 1) {
                                 Toast.makeText(this, "알림 저장 완료", Toast.LENGTH_SHORT).show();
                                 finish();

--- a/app/src/main/res/layout/item_alarm_list.xml
+++ b/app/src/main/res/layout/item_alarm_list.xml
@@ -21,4 +21,13 @@
         android:text="복용 시간대"
         android:textSize="14sp"
         android:layout_marginTop="4dp" />
+
+    <ImageButton
+        android:id="@+id/btnDelete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_delete"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:layout_gravity="end"
+        android:contentDescription="삭제" />
 </LinearLayout>


### PR DESCRIPTION
## Summary
- set userId dynamically using FirebaseAuth when editing alarms
- schedule notifications for each alarm
- allow deleting alarms from the list
- delete alarm across all saved days and cancel all notifications
- fix crash when saving edited alarms

## Testing
- `sh ./gradlew help` *(fails: `Unable to tunnel through proxy`)*

------
https://chatgpt.com/codex/tasks/task_e_68482fbaf808832aba50715358d57307